### PR TITLE
[MOBILE-2302] Patch Fix to Enable HTTP URL .zip Downloads

### DIFF
--- a/Tophat/Info.plist
+++ b/Tophat/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
- This PR includes two changes to enable HTTP URL downloads (e.g., .zip files from S3 buckets): workaround fix for downloading in `ArtifactDownloader.swift` and adding `NSAllowsArbitraryLoads` to `Info.plist`.
- Verified locally with S3 URL

https://github.com/user-attachments/assets/9a04c9e6-7d9a-4664-8224-982023a5854a
